### PR TITLE
refactor(Field::Resolve) simplify args check

### DIFF
--- a/spec/graphql/query/variables_spec.rb
+++ b/spec/graphql/query/variables_spec.rb
@@ -33,6 +33,12 @@ describe GraphQL::Query::Variables do
     end
 
     describe "nullable variables" do
+      module ObjectWithThingsCount
+        def self.thingsCount(args, ctx) # rubocop:disable Style/MethodName
+          1
+        end
+      end
+
       let(:schema) { GraphQL::Schema.from_definition(%|
         type Query {
           thingsCount(ids: [ID!]): Int!
@@ -45,7 +51,7 @@ describe GraphQL::Query::Variables do
         }
       |}
       let(:result) {
-        schema.execute(query_string, variables: provided_variables, root_value: OpenStruct.new(thingsCount: 1))
+        schema.execute(query_string, variables: provided_variables, root_value: ObjectWithThingsCount)
       }
 
       describe "when they are present, but null" do

--- a/spec/graphql/schema/warden_spec.rb
+++ b/spec/graphql/schema/warden_spec.rb
@@ -112,7 +112,7 @@ module MaskHelpers
 
   module Data
     UVULAR_TRILL = OpenStruct.new({name: "Uvular Trill", symbol: "ʀ", manner: "TRILL"})
-    def self.unit
+    def self.unit(args, ctx)
       UVULAR_TRILL
     end
   end


### PR DESCRIPTION
Would it be feasible to only check if the field was _defined_ with any arguments? In this case, it's the user's requirement to ensure that the underlying objects accept the correct arguments. 

To improve developer experience, we could `rescue ArgumentError` and raise a more descriptive error.

This is theoretically a breaking change (as shown by the required changes to the tests) but I think the real-world impact will be minimal. The objects in the tests were only fixtures which didn't even work properly to start with!